### PR TITLE
Added the test annotation classes

### DIFF
--- a/PL2/PL2-gui/pom.xml
+++ b/PL2/PL2-gui/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>PL2-shared</artifactId>
             <version>${PL2-shared-version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/PL2/PL2-shared/pom.xml
+++ b/PL2/PL2-shared/pom.xml
@@ -10,6 +10,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>PL2-shared</artifactId>
-
-
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/AccessPrivate.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/AccessPrivate.java
@@ -1,0 +1,192 @@
+package nl.tudelft.pl2016gr2.testUtility;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Access a private method or field which is annotated with the {@link TestId}
+ * annotation. Uniqueness of a requested test ID will always be checked whenever
+ * a method or field is accessed. It is possible to access non-private (for
+ * example protected) fields/methods too, although this isn't the intended
+ * purpose of this class. <br>
+ * If the requested ID is not present in the specified class, or if the ID is
+ * not unique then a {@link TestAnnotationException} is thrown.
+ *
+ * @author Faris
+ */
+public final class AccessPrivate {
+
+	/**
+	 * Don't let anyone instantiate this class.
+	 */
+	private AccessPrivate() {
+	}
+
+	/**
+	 * Call the method with the specified id of the specified object.
+	 *
+	 * @param id the annotated id of the method.
+	 * @param cl the class of the method.
+	 * @param obj the object the method is called on. Can be null if the method
+	 * is static.
+	 * @param params the parameters of the method.
+	 * @return the returned value of the method.
+	 */
+	public static Object callMethod(String id, Class cl, Object obj,
+			Object... params) {
+		Method method = getMethod(cl, id);
+		try {
+			method.setAccessible(true);
+			Object res = method.invoke(obj, params);
+			method.setAccessible(false);
+			return res;
+		} catch (IllegalAccessException | IllegalArgumentException |
+				InvocationTargetException ex) {
+			Logger.getLogger(
+					AccessPrivate.class.getName()).log(Level.SEVERE, null, ex);
+		}
+		throw new TestAnnotationException("An error occured while accessing the"
+				+ " method with test id: " + id + ".");
+	}
+
+	/**
+	 * Get the method with the specified id and assure the id is unique.
+	 *
+	 * @param cl the class of the method.
+	 * @param id the id of the method.
+	 * @return the method with the specified id.
+	 */
+	private static Method getMethod(Class cl, String id) {
+		Method foundMethod = null;
+		int foundMethods = 0;
+
+		for (Method method : cl.getDeclaredMethods()) {
+			if (checkAnnotated(method.getAnnotationsByType(TestId.class), id)) {
+				foundMethod = method;
+				++foundMethods;
+			}
+		}
+		if (foundMethods != 1) {
+			throw createUniquenessException(cl, id, foundMethods);
+		}
+		return foundMethod;
+	}
+
+	/**
+	 * Get the value of the specified field of the specified object.
+	 *
+	 * @param id the annotated id of the field.
+	 * @param cl the class of the field.
+	 * @param obj the object which contains the field. Can be null if the field
+	 * is static.
+	 * @return the returned value of the field.
+	 */
+	public static Object getFieldValue(String id, Class cl, Object obj) {
+		try {
+			Field field = AccessPrivate.getField(cl, id);
+			field.setAccessible(true);
+			Object res = field.get(obj);
+			field.setAccessible(false);
+			return res;
+		} catch (IllegalArgumentException | IllegalAccessException ex) {
+			Logger.getLogger(AccessPrivate.class.getName()).log(Level.SEVERE,
+					null, ex);
+		}
+		return null;
+	}
+
+	/**
+	 * Set the value of the specified field of the specified object.
+	 *
+	 * @param id the annotated id of the field.
+	 * @param cl the class of the field.
+	 * @param obj the object which contains the field. Can be null if the field
+	 * is static.
+	 * @param value the new value of the field.
+	 */
+	public static void setFieldValue(String id, Class cl, Object obj,
+			Object value) {
+		try {
+			Field field = AccessPrivate.getField(cl, id);
+			if (Modifier.isFinal(field.getModifiers())) {
+				throw new TestAnnotationException("Trying to set the value of "
+						+ "the final field with id: " + id + ".");
+			}
+			field.setAccessible(true);
+			field.set(obj, value);
+			field.setAccessible(false);
+		} catch (IllegalArgumentException | IllegalAccessException ex) {
+			Logger.getLogger(AccessPrivate.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
+
+	/**
+	 * Get the field of the specified object. Also assure that the found field
+	 * is unique.
+	 *
+	 * @param cl the class of the field.
+	 * @param id the annotated id of the field.
+	 * @return the returned value of the field.
+	 */
+	private static Field getField(Class cl, String id) {
+		Field foundField = null;
+		int foundFields = 0;
+
+		for (Field field : cl.getDeclaredFields()) {
+			if (checkAnnotated(field.getAnnotationsByType(TestId.class), id)) {
+				foundField = field;
+				++foundFields;
+			}
+		}
+		if (foundFields != 1) {
+			throw createUniquenessException(cl, id, foundFields);
+		}
+		return foundField;
+	}
+
+	/**
+	 * Create an exception according to the amount of times an id was found
+	 * (either the id was not found, or the id was found too many times).
+	 *
+	 * @param id the id.
+	 * @param found the amount of times the id was found.
+	 * @return an appropriate exception.
+	 */
+	private static TestAnnotationException createUniquenessException(Class cl,
+			String id,
+			int found) {
+		assert found != 1;
+		switch (found) {
+			case 0:
+				return new TestAnnotationException("The requested id: " + id
+						+ " was not found inclass: " + cl.toString() + ".");
+			default:
+				return new TestAnnotationException("The requested id: " + id
+						+ " is not unique. It was found " + found
+						+ " times in class: " + cl.toString() + ".");
+		}
+	}
+
+	/**
+	 * Check if the list of annotations contains a TestId annotation with the
+	 * right id.
+	 *
+	 * @param annotations the annotations.
+	 * @param id the id of the test annotation.
+	 * @return if the list of annotations contains a TestId annotation with the
+	 * right id.
+	 */
+	private static boolean checkAnnotated(Annotation[] annotations, String id) {
+		for (Annotation annotation : annotations) {
+			if (annotation.annotationType().equals(TestId.class)) {
+				return ((TestId) annotation).id().equals(id);
+			}
+		}
+		return false;
+	}
+}

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/TestAnnotationException.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/TestAnnotationException.java
@@ -1,0 +1,30 @@
+package nl.tudelft.pl2016gr2.testUtility;
+
+/**
+ * An exception which is thrown when there is something wrong with the test
+ * annotation. This exception is a runtime exception and isn't intended to be
+ * caught.
+ *
+ * @see RuntimeException
+ *
+ * @author Faris
+ */
+public class TestAnnotationException extends RuntimeException {
+
+	/**
+	 * Creates a new instance of <code>NotAnnotatedException</code> without
+	 * detail message.
+	 */
+	public TestAnnotationException() {
+	}
+
+	/**
+	 * Constructs an instance of <code>NotAnnotatedException</code> with the
+	 * specified detail message.
+	 *
+	 * @param msg the detail message.
+	 */
+	public TestAnnotationException(String msg) {
+		super(msg);
+	}
+}

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/TestId.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/testUtility/TestId.java
@@ -1,0 +1,24 @@
+package nl.tudelft.pl2016gr2.testUtility;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation which makes it possible to give private methods and fields an ID
+ * so they can be accessed by test classes using the AccessPrivate class.
+ *
+ * @author Faris
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface TestId {
+
+	/**
+	 * The ID of the field or method.
+	 *
+	 * @return the ID.
+	 */
+	public String id();
+}

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/testUtility/AccessPrivateTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/testUtility/AccessPrivateTest.java
@@ -1,0 +1,107 @@
+package nl.tudelft.pl2016gr2.testUtility;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * This class tests if the test utility classes work correctly.
+ * @author faris
+ */
+public class AccessPrivateTest {
+	
+    /**
+     * Test call private method.
+     */
+    @Test
+    public void privateMethodTest() {
+        PrivateMemberClass instance = new PrivateMemberClass();
+        Object ret = AccessPrivate.callMethod("m_getNumber", 
+				PrivateMemberClass.class, instance);
+        assertEquals(5, ret);
+    }
+
+    /**
+     * Test call static private method.
+     */
+    @Test
+    public void privateStaticMethodTest() {
+        Object ret = AccessPrivate.callMethod("m_getNumberStatic", 
+				PrivateMemberClass.class, null);
+        assertEquals(6, ret);
+    }
+
+    /**
+     * Test call method with parameter.
+     */
+    @Test
+    public void privateStaticMethodWithParameterTest() {
+        Object ret
+                = AccessPrivate.callMethod("m_returnNumber", 
+						PrivateMemberClass.class, null, 7, 8);
+        assertEquals(15, ret);
+    }
+
+    /**
+     * Test get private field.
+     */
+    @Test
+    public void privateFieldAccessTest() {
+        PrivateMemberClass instance = new PrivateMemberClass();
+        Object ret = AccessPrivate.getFieldValue("f_testVar", 
+				PrivateMemberClass.class, instance);
+        assertEquals(456, ret);
+    }
+
+    /**
+     * Test get private static field.
+     */
+    @Test
+    public void privateStaticFieldAccessTest() {
+        Object ret = AccessPrivate.getFieldValue("f_staticTestVar", 
+				PrivateMemberClass.class, null);
+        assertEquals(234, ret);
+    }
+
+    /**
+     * Test set private field.
+     */
+    @Test
+    public void setPrivateFieldTest() {
+        PrivateMemberClass instance = new PrivateMemberClass();
+        String privateChangebleVar = "f_changeableTestVar";
+        AccessPrivate.setFieldValue(privateChangebleVar, 
+				PrivateMemberClass.class, instance, -1);
+        assertEquals(-1, AccessPrivate.getFieldValue(privateChangebleVar, 
+				PrivateMemberClass.class,                instance));
+    }
+
+    /**
+     * Test set private static field.
+     */
+    @Test
+    public void setPrivateStaticFieldTest() {
+        String privateChangebleVar = "f_changeableStaticTestVar";
+        AccessPrivate.setFieldValue(privateChangebleVar, 
+				PrivateMemberClass.class, null, -2);
+        assertEquals(-2, AccessPrivate.getFieldValue(privateChangebleVar,
+                PrivateMemberClass.class, null));
+    }
+
+    /**
+     * Test correct exception when trying to set private final field.
+     */
+    @Test(expected = TestAnnotationException.class)
+    public void setPrivateFinalFieldTest() {
+        AccessPrivate.setFieldValue("f_testVar", PrivateMemberClass.class, 
+				null, -6);
+    }
+
+    /**
+     * Test correct exception when asking for non-existent id.
+     */
+    @Test(expected = TestAnnotationException.class)
+    public void annotationExceptionTest() {
+        AccessPrivate.getFieldValue("NON_EXISTING_FIELD", 
+				PrivateMemberClass.class, null);
+    }
+}

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/testUtility/PrivateMemberClass.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/testUtility/PrivateMemberClass.java
@@ -1,0 +1,50 @@
+package nl.tudelft.pl2016gr2.testUtility;
+
+/**
+ * This class is for testing if we are correctly able to access it's private members.
+ *
+ * @author Faris
+ */
+public class PrivateMemberClass {
+
+    @TestId(id = "f_testVar")
+    private final int testVar = 456;
+    @TestId(id = "f_staticTestVar")
+    private final static int staticTestVar = 234;
+    @TestId(id = "f_changeableTestVar")
+    private int changeableTestVar = 0;
+    @TestId(id = "f_changeableStaticTestVar")
+    private static int changeableStaticTestVar = 0;
+
+    /**
+     * A private method whitch returns 5.
+     *
+     * @return the number 5.
+     */
+    @TestId(id = "m_getNumber")
+    private int getNumber() {
+        return 5;
+    }
+
+    /**
+     * A private static method whitch returns 6.
+     *
+     * @return the number 6.
+     */
+    @TestId(id = "m_getNumberStatic")
+    private static int getNumberStatic() {
+        return 6;
+    }
+
+    /**
+     * a private static method which returns the first + second parameter.
+     *
+     * @param number1 a number.
+     * @param number2 a number.
+     * @return the first + second parameter.
+     */
+    @TestId(id = "m_returnNumber")
+    private static int returnNumber(int number1, int number2) {
+        return number1 + number2;
+    }
+}


### PR DESCRIPTION
Added the test annotation classes, which I've shown last week during a meeting, to the project. Check the AccessPrivateTest and PrivateMemberClass test classes in the test package of the shared module to see how to use the test annotation.
