### PR TITLE
Bug fix: tree could get GCed.

### DIFF
--- a/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/AlgoRunner.java
+++ b/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/AlgoRunner.java
@@ -10,7 +10,7 @@ import nl.tudelft.pl2016gr2.parser.controller.GFAReader;
  */
 public class AlgoRunner {
 	
-	public static final String FILENAME = AlgoRunner.class.getClassLoader().getResource("TB10.gfa").getFile();
+	public static final String FILENAME = "TB10.gfa";
 	public static final int GRAPH_SIZE = 8728;
 	//public static final int GRAPH_SIZE = 10;
 

--- a/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/model/PhylogeneticTreeNode.java
+++ b/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/model/PhylogeneticTreeNode.java
@@ -61,7 +61,7 @@ public class PhylogeneticTreeNode implements IPhylogeneticTreeNode {
             return false;
         }
         final PhylogeneticTreeNode other = (PhylogeneticTreeNode) obj;
-        return Objects.equals(this.node, other.node);
+        return this.node == other.node;
     }
 
 }

--- a/PL2/PL2-launcher/src/main/java/nl/tudelft/pl2016gr2/launcher/Dnav.java
+++ b/PL2/PL2-launcher/src/main/java/nl/tudelft/pl2016gr2/launcher/Dnav.java
@@ -24,6 +24,8 @@ import nl.tudelft.pl2016gr2.parser.controller.GFAReader;
  */
 public class Dnav extends Application {
 
+	private Tree tree;
+
 	/**
 	 * Start the application. This method is automatically called by JavaFX when
 	 * the API is initialized, after the call to launch(args) in the main
@@ -58,7 +60,7 @@ public class Dnav extends Application {
 		BufferedReader br = new BufferedReader(r);
 		TreeParser tp = new TreeParser(br);
 
-		Tree tree = tp.tokenize("340tree.rooted.TKK");
+		tree = tp.tokenize("340tree.rooted.TKK");
 		controller.setData(new PhylogeneticTreeNode(tree.getRoot()));
 		try {
 			r.close();

--- a/PL2/PL2-parser/src/main/java/nl/tudelft/pl2016gr2/parser/controller/GFAReader.java
+++ b/PL2/PL2-parser/src/main/java/nl/tudelft/pl2016gr2/parser/controller/GFAReader.java
@@ -29,12 +29,7 @@ public class GFAReader {
 	 */
 	public GFAReader(String filename, int graphsize) {
 		this.NUM_NODES = graphsize;
-		File f = new File(filename);
-		try {
-			this.sc = new Scanner(f);
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		}		
+		this.sc = new Scanner(GFAReader.class.getClassLoader().getResourceAsStream(filename));
 		prepNodes();
 		read();
 		


### PR DESCRIPTION
The tree object could be garbage collected by the JVM,  which called the finalize method on the tree class (which is an external dependency), which then cleared the content of some of the child array lists. This is fixed by keeping a reference to the tree object in the main class.
