### PR TITLE
Improved the use of generics in the AccessPrivate class

### DIFF
--- a/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/FilterSnipsTest.java
+++ b/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/FilterSnipsTest.java
@@ -7,18 +7,17 @@ import static org.junit.Assert.assertTrue;
 import nl.tudelft.pl2016gr2.model.Node;
 import nl.tudelft.pl2016gr2.model.OriginalGraph;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 
 public class FilterSnipsTest {
-  
+
   private OriginalGraph graph = new OriginalGraph();
-  
+
   /**
-   * Make graph.
+   * Make graph. 
     //
     //    - 2 -       - 5 -       - 8
     // 1 -      - 4 -       - 7 - 
@@ -53,16 +52,13 @@ public class FilterSnipsTest {
   }
 
   /**
-   * Test filter method. The resulting graph should have 3 nodes:
-   *    - 8
-   * 1 -
-   *    - 9
+   * Test filter method. The resulting graph should have 3 nodes: - 8 1 - - 9
    */
   @Test
   public void testFilter() {
     FilterSnips filter = new FilterSnips(graph);
     OriginalGraph filteredGraph = filter.filter();
-    
+
     assertEquals(3, filteredGraph.getSize());
     Node root = filteredGraph.getRoot();
     assertEquals(1, root.getId());
@@ -72,78 +68,72 @@ public class FilterSnipsTest {
     assertEquals(graph.getNode(8), filteredGraph.getNode(8));
     assertEquals(graph.getNode(9), filteredGraph.getNode(9));
   }
-  
+
   /**
-   * Test method make snip for node 1. It should merge all nodes between 1 and 7 into
-   * one node.
+   * Test method make snip for node 1. It should merge all nodes between 1 and 7 into one node.
    */
   @Test
   public void testMakeSnip() {
     FilterSnips filter = new FilterSnips(graph);
-    Node snip = (Node)AccessPrivate.callMethod("method_makeSnip", FilterSnips.class, 
-        filter, graph.getNode(1));
+    Node snip = AccessPrivate.callMethod("method_makeSnip", FilterSnips.class, filter,
+        graph.getNode(1));
 
     assertEquals(2, snip.getOutlinks().size());
     assertTrue(snip.getOutlinks().contains(8));
     assertTrue(snip.getOutlinks().contains(9));
-    
+
     assertEquals(0, snip.getInlinks().size());
-    
+
     assertEquals(1, snip.getId());
     assertEquals(2, snip.getSnips());
   }
-  
+
   /**
-   * Test method make snip for node 4. It should merge all nodes between 4 and 7 into 
-   * one node.
+   * Test method make snip for node 4. It should merge all nodes between 4 and 7 into one node.
    */
   @Test
   public void testMakeSnipNodeFour() {
     FilterSnips filter = new FilterSnips(graph);
-    Node snip = (Node)AccessPrivate.callMethod("method_makeSnip", FilterSnips.class, 
-        filter, graph.getNode(4));
+    Node snip = AccessPrivate.callMethod("method_makeSnip", FilterSnips.class, filter, 
+        graph.getNode(4));
 
     assertEquals(2, snip.getOutlinks().size());
     assertTrue(snip.getOutlinks().contains(8));
     assertTrue(snip.getOutlinks().contains(9));
-    
+
     assertEquals(2, snip.getInlinks().size());
     assertTrue(snip.getInlinks().contains(2));
     assertTrue(snip.getInlinks().contains(3));
-    
+
     assertEquals(4, snip.getId());
     assertEquals(1, snip.getSnips());
   }
-  
+
   /**
-   * Test method is snip for node 1 (which is a snip). So the method should
-   * return true.
+   * Test method is snip for node 1 (which is a snip). So the method should return true.
    */
   @Test
   public void testIsSnipTrue() {
     FilterSnips filter = new FilterSnips(graph);
-    Object ret = AccessPrivate.callMethod("method_isSnip", FilterSnips.class, 
-        filter, graph.getNode(1));
-    assertTrue((boolean)ret);
+    boolean ret = AccessPrivate.callMethod("method_isSnip", FilterSnips.class, filter, 
+        graph.getNode(1));
+    assertTrue(ret);
   }
-  
+
   /**
-   * Test method is snip for node 2 (which is not a snip). So the method should
-   * return false.
+   * Test method is snip for node 2 (which is not a snip). So the method should return false.
    */
   @Test
   public void testIsSnipFalse() {
     FilterSnips filter = new FilterSnips(graph);
-    Object ret = AccessPrivate.callMethod("method_isSnip", FilterSnips.class, 
-        filter, graph.getNode(2));
-    assertFalse((boolean)ret);
+    boolean ret = AccessPrivate.callMethod("method_isSnip", FilterSnips.class, filter, 
+        graph.getNode(2));
+    assertFalse(ret);
   }
-  
-  
+
   /**
-   * Test method update links. The outlinks of node 1 are set to 5 and 6,
-   * to pretend it is a snip from node 1 to 4. So the inlink of node 5 and 6,
-   * which is 4 now, should be changed to 1.
+   * Test method update links. The outlinks of node 1 are set to 5 and 6, to pretend it is a snip
+   * from node 1 to 4. So the inlink of node 5 and 6, which is 4 now, should be changed to 1.
    */
   @Test
   public void testUpdateLinks() {

--- a/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/selection/DescriptionPaneTest.java
+++ b/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/selection/DescriptionPaneTest.java
@@ -6,10 +6,8 @@ import static org.mockito.Mockito.verify;
 
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
-
 import nl.tudelft.pl2016gr2.gui.javafxrunner.JavaFxJUnit4ClassRunner;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -31,7 +29,7 @@ public class DescriptionPaneTest {
     Scene scene = new Scene(parent);
     DescriptionPane description = new DescriptionPane(parent, parent);
     assertTrue(parent.getChildren().contains(description));
-    FrostGlassEffect effect = (FrostGlassEffect) AccessPrivate.getFieldValue("frostGlassEffect",
+    FrostGlassEffect effect = AccessPrivate.getFieldValue("frostGlassEffect",
         DescriptionPane.class, description);
     assertTrue(description.getChildren().contains(effect.getEffect()));
   }

--- a/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/TreeManagerTest.java
+++ b/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/TreeManagerTest.java
@@ -8,12 +8,10 @@ import static org.mockito.Mockito.when;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.Pane;
-
 import nl.tudelft.pl2016gr2.gui.javafxrunner.JavaFxJUnit4ClassRunner;
 import nl.tudelft.pl2016gr2.gui.model.IPhylogeneticTreeNode;
 import nl.tudelft.pl2016gr2.gui.view.selection.SelectionManager;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +66,7 @@ public class TreeManagerTest {
     mockLeafLl();
     initializeTreeManager();
   }
-  
+
   /**
    * Initialize a tree manager.
    */

--- a/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/ViewNodeTest.java
+++ b/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/ViewNodeTest.java
@@ -9,11 +9,9 @@ import javafx.animation.Timeline;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
-
 import nl.tudelft.pl2016gr2.gui.model.IPhylogeneticTreeNode;
 import nl.tudelft.pl2016gr2.gui.view.selection.SelectionManager;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,8 +153,8 @@ public class ViewNodeTest {
    */
   @Test
   public void testDrawNodeTreeStructureFirstLevel() {
-    ArrayList<ViewNode> rootChildren
-        = (ArrayList) AccessPrivate.getFieldValue("children", ViewNode.class, viewNode);
+    ArrayList<ViewNode> rootChildren = AccessPrivate.getFieldValue("children", ViewNode.class,
+        viewNode);
     assertEquals(2, rootChildren.size());
     assertEquals(leafR, rootChildren.get(0).getDataNode());
     assertEquals(leafL, rootChildren.get(1).getDataNode());
@@ -168,12 +166,12 @@ public class ViewNodeTest {
    */
   @Test
   public void testDrawNodeTreeStructureSecondLevel() {
-    ArrayList<ViewNode> rootChildren
-        = (ArrayList) AccessPrivate.getFieldValue("children", ViewNode.class, viewNode);
-    ArrayList<ViewNode> rightChildren
-        = (ArrayList) AccessPrivate.getFieldValue("children", ViewNode.class, rootChildren.get(0));
-    ArrayList<ViewNode> leftChildren
-        = (ArrayList) AccessPrivate.getFieldValue("children", ViewNode.class, rootChildren.get(1));
+    ArrayList<ViewNode> rootChildren = AccessPrivate.getFieldValue("children",
+        ViewNode.class, viewNode);
+    ArrayList<ViewNode> rightChildren = AccessPrivate.getFieldValue("children", ViewNode.class,
+        rootChildren.get(0));
+    ArrayList<ViewNode> leftChildren = AccessPrivate.getFieldValue("children", ViewNode.class,
+        rootChildren.get(1));
     assertEquals(0, rightChildren.size());
     assertEquals(0, leftChildren.size());
   }
@@ -194,8 +192,8 @@ public class ViewNodeTest {
    */
   @Test
   public void testZoomIn() {
-    ArrayList<ViewNode> rootChildren
-        = (ArrayList) AccessPrivate.getFieldValue("children", ViewNode.class, viewNode);
+    ArrayList<ViewNode> rootChildren = AccessPrivate.getFieldValue("children", ViewNode.class,
+        viewNode);
     Timeline timeline = new Timeline();
     viewNode.zoomIn(rootChildren.get(1), timeline);
     assertEquals(3, timeline.getKeyFrames().size());

--- a/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/heatmap/HeatmapManagerTest.java
+++ b/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/heatmap/HeatmapManagerTest.java
@@ -6,10 +6,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import javafx.scene.layout.Pane;
-
 import nl.tudelft.pl2016gr2.gui.view.tree.ViewNode;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -28,13 +26,12 @@ public class HeatmapManagerTest {
   @Test
   public void testInitLeaves() {
     HeatmapManager heatmapManager = new HeatmapManager(new Pane());
-    NodeDensityHeatmap densityMap = (NodeDensityHeatmap) AccessPrivate.getFieldValue("densityMap",
-        HeatmapManager.class, heatmapManager);
+    NodeDensityHeatmap densityMap = AccessPrivate.getFieldValue("densityMap", HeatmapManager.class, 
+        heatmapManager);
     assertEquals(null, densityMap);
     heatmapManager.initLeaves(new ArrayList<>());
-    densityMap = (NodeDensityHeatmap) AccessPrivate.getFieldValue("densityMap",
-        HeatmapManager.class, heatmapManager);
-    ArrayList<ViewNode> leaves = (ArrayList) AccessPrivate.getFieldValue("currentLeaves",
+    densityMap = AccessPrivate.getFieldValue("densityMap", HeatmapManager.class, heatmapManager);
+    ArrayList<ViewNode> leaves = AccessPrivate.getFieldValue("currentLeaves",
         NodeDensityHeatmap.class, densityMap);
     assertTrue(leaves.isEmpty());
   }

--- a/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/heatmap/NodeDensityHeatmapTest.java
+++ b/PL2/PL2-gui/src/test/java/nl/tudelft/pl2016gr2/gui/view/tree/heatmap/NodeDensityHeatmapTest.java
@@ -8,12 +8,10 @@ import static org.mockito.Mockito.when;
 
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
-
 import nl.tudelft.pl2016gr2.gui.model.IPhylogeneticTreeNode;
 import nl.tudelft.pl2016gr2.gui.view.tree.Area;
 import nl.tudelft.pl2016gr2.gui.view.tree.ViewNode;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -60,12 +58,12 @@ public class NodeDensityHeatmapTest {
     when(viewNode.getDataNode()).thenReturn(dataNode5, dataNode10);
     when(dataNode10.getChildCount()).thenReturn(10);
     when(dataNode5.getChildCount()).thenReturn(5);
-    ArrayList<ViewNode> nodeList = new ArrayList();
+    ArrayList<ViewNode> nodeList = new ArrayList<>();
     nodeList.add(viewNode);
     nodeList.add(viewNode);
     NodeDensityHeatmap heatmap = Mockito.mock(NodeDensityHeatmap.class);
     AccessPrivate.setFieldValue("currentLeaves", NodeDensityHeatmap.class, heatmap, nodeList);
-    int maxChildren = (int) AccessPrivate.callMethod("getMaxChildren", NodeDensityHeatmap.class,
+    int maxChildren = AccessPrivate.callMethod("getMaxChildren", NodeDensityHeatmap.class,
         heatmap);
     assertEquals(10, maxChildren);
   }
@@ -76,8 +74,8 @@ public class NodeDensityHeatmapTest {
    */
   @Test
   public void testMapColor() {
-    Color c5 = (Color) AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 5, 10);
-    Color c6 = (Color) AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 6, 10);
+    Color c5 = AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 5, 10);
+    Color c6 = AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 6, 10);
     assertTrue(c5.getBrightness() > c6.getBrightness());
   }
 }

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/thirdparty/testing/utility/AccessPrivate.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/thirdparty/testing/utility/AccessPrivate.java
@@ -9,13 +9,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Access a private method or field which is annotated with the {@link TestId}
- * annotation. Uniqueness of a requested test ID will always be checked whenever
- * a method or field is accessed. It is possible to access non-private (for
- * example protected) fields/methods too, although this isn't the intended
- * purpose of this class. <br>
- * If the requested ID is not present in the specified class, or if the ID is
- * not unique then a {@link TestAnnotationException} is thrown.
+ * Access a private method or field which is annotated with the {@link TestId} annotation.
+ * Uniqueness of a requested test ID will always be checked whenever a method or field is accessed.
+ * It is possible to access non-private (for example protected) fields/methods too, although this
+ * isn't the intended purpose of this class. <br>
+ * If the requested ID is not present in the specified class, or if the ID is not unique then a
+ * {@link TestAnnotationException} is thrown.
  *
  * @author Faris
  */
@@ -30,38 +29,33 @@ public final class AccessPrivate {
   /**
    * Call the method with the specified id of the specified object.
    *
-   * @param id
-   *          the annotated id of the method.
-   * @param cl
-   *          the class of the method.
-   * @param obj
-   *          the object the method is called on. Can be null if the method is
-   *          static.
-   * @param params
-   *          the parameters of the method.
+   * @param <R>    the return type.
+   * @param <T>    the type of the object that contains the method to call.
+   * @param id     the annotated id of the method.
+   * @param cl     the class of the method.
+   * @param obj    the object the method is called on. Can be null if the method is static.
+   * @param params the parameters of the method.
    * @return the returned value of the method.
    */
-  public static Object callMethod(String id, Class cl, Object obj, Object... params) {
+  public static <R, T> R callMethod(String id, Class<T> cl, T obj, Object... params) {
     Method method = getMethod(cl, id);
     try {
       method.setAccessible(true);
       Object res = method.invoke(obj, params);
       method.setAccessible(false);
-      return res;
+      return (R) res;
     } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
       Logger.getLogger(AccessPrivate.class.getName()).log(Level.SEVERE, null, ex);
     }
-    throw new TestAnnotationException("An error occured while accessing the" 
+    throw new TestAnnotationException("An error occured while accessing the"
         + " method with test id: " + id + ".");
   }
 
   /**
    * Get the method with the specified id and assure the id is unique.
    *
-   * @param cl
-   *          the class of the method.
-   * @param id
-   *          the id of the method.
+   * @param cl the class of the method.
+   * @param id the id of the method.
    * @return the method with the specified id.
    */
   private static Method getMethod(Class cl, String id) {
@@ -83,22 +77,20 @@ public final class AccessPrivate {
   /**
    * Get the value of the specified field of the specified object.
    *
-   * @param id
-   *          the annotated id of the field.
-   * @param cl
-   *          the class of the field.
-   * @param obj
-   *          the object which contains the field. Can be null if the field is
-   *          static.
+   * @param <R> the return type.
+   * @param <T> the type of the object that contains the field to get.
+   * @param id  the annotated id of the field.
+   * @param cl  the class of the field.
+   * @param obj the object which contains the field. Can be null if the field is static.
    * @return the returned value of the field.
    */
-  public static Object getFieldValue(String id, Class cl, Object obj) {
+  public static <R, T> R getFieldValue(String id, Class<T> cl, T obj) {
     try {
       Field field = AccessPrivate.getField(cl, id);
       field.setAccessible(true);
       Object res = field.get(obj);
       field.setAccessible(false);
-      return res;
+      return (R) res;
     } catch (IllegalArgumentException | IllegalAccessException ex) {
       Logger.getLogger(AccessPrivate.class.getName()).log(Level.SEVERE, null, ex);
     }
@@ -108,21 +100,17 @@ public final class AccessPrivate {
   /**
    * Set the value of the specified field of the specified object.
    *
-   * @param id
-   *          the annotated id of the field.
-   * @param cl
-   *          the class of the field.
-   * @param obj
-   *          the object which contains the field. Can be null if the field is
-   *          static.
-   * @param value
-   *          the new value of the field.
+   * @param <T>   the type of the class that contains the field to set.
+   * @param id    the annotated id of the field.
+   * @param cl    the class of the field.
+   * @param obj   the object which contains the field. Can be null if the field is static.
+   * @param value the new value of the field.
    */
-  public static void setFieldValue(String id, Class cl, Object obj, Object value) {
+  public static <T> void setFieldValue(String id, Class<T> cl, T obj, Object value) {
     try {
       Field field = AccessPrivate.getField(cl, id);
       if (Modifier.isFinal(field.getModifiers())) {
-        throw new TestAnnotationException("Trying to set the value of " 
+        throw new TestAnnotationException("Trying to set the value of "
             + "the final field with id: " + id + ".");
       }
       field.setAccessible(true);
@@ -134,13 +122,10 @@ public final class AccessPrivate {
   }
 
   /**
-   * Get the field of the specified object. Also assure that the found field is
-   * unique.
+   * Get the field of the specified object. Also assure that the found field is unique.
    *
-   * @param cl
-   *          the class of the field.
-   * @param id
-   *          the annotated id of the field.
+   * @param cl the class of the field.
+   * @param id the annotated id of the field.
    * @return the returned value of the field.
    */
   private static Field getField(Class cl, String id) {
@@ -160,20 +145,18 @@ public final class AccessPrivate {
   }
 
   /**
-   * Create an exception according to the amount of times an id was found
-   * (either the id was not found, or the id was found too many times).
+   * Create an exception according to the amount of times an id was found (either the id was not
+   * found, or the id was found too many times).
    *
-   * @param id
-   *          the id.
-   * @param found
-   *          the amount of times the id was found.
+   * @param id    the id.
+   * @param found the amount of times the id was found.
    * @return an appropriate exception.
    */
   private static TestAnnotationException createUniquenessException(Class cl, String id, int found) {
     assert found != 1;
     if (found == 0) {
-      return new TestAnnotationException("The requested id: " + id + " was not found inclass: " 
-        + cl.toString() + ".");
+      return new TestAnnotationException("The requested id: " + id + " was not found inclass: "
+          + cl.toString() + ".");
     } else {
       return new TestAnnotationException("The requested id: " + id + " is not unique. It was found "
           + found + " times in class: " + cl.toString() + ".");
@@ -181,15 +164,11 @@ public final class AccessPrivate {
   }
 
   /**
-   * Check if the list of annotations contains a TestId annotation with the
-   * right id.
+   * Check if the list of annotations contains a TestId annotation with the right id.
    *
-   * @param annotations
-   *          the annotations.
-   * @param id
-   *          the id of the test annotation.
-   * @return if the list of annotations contains a TestId annotation with the
-   *         right id.
+   * @param annotations the annotations.
+   * @param id          the id of the test annotation.
+   * @return if the list of annotations contains a TestId annotation with the right id.
    */
   private static boolean checkAnnotated(Annotation[] annotations, String id) {
     for (Annotation annotation : annotations) {

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/test/utility/AccessPrivateTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/test/utility/AccessPrivateTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.AccessPrivate;
 import nl.tudelft.pl2016gr2.thirdparty.testing.utility.TestAnnotationException;
-
 import org.junit.Test;
 
 /**
@@ -20,8 +19,7 @@ public class AccessPrivateTest {
   @Test
   public void privateMethodTest() {
     PrivateMemberClass instance = new PrivateMemberClass();
-    Object ret = AccessPrivate.callMethod("m_getNumber",
-        PrivateMemberClass.class, instance);
+    int ret = AccessPrivate.callMethod("m_getNumber", PrivateMemberClass.class, instance);
     assertEquals(5, ret);
   }
 
@@ -30,8 +28,7 @@ public class AccessPrivateTest {
    */
   @Test
   public void privateStaticMethodTest() {
-    Object ret = AccessPrivate.callMethod("m_getNumberStatic",
-        PrivateMemberClass.class, null);
+    int ret = AccessPrivate.callMethod("m_getNumberStatic", PrivateMemberClass.class, null);
     assertEquals(6, ret);
   }
 
@@ -40,9 +37,7 @@ public class AccessPrivateTest {
    */
   @Test
   public void privateStaticMethodWithParameterTest() {
-    Object ret
-        = AccessPrivate.callMethod("m_returnNumber",
-            PrivateMemberClass.class, null, 7, 8);
+    int ret = AccessPrivate.callMethod("m_returnNumber", PrivateMemberClass.class, null, 7, 8);
     assertEquals(15, ret);
   }
 
@@ -52,8 +47,7 @@ public class AccessPrivateTest {
   @Test
   public void privateFieldAccessTest() {
     PrivateMemberClass instance = new PrivateMemberClass();
-    Object ret = AccessPrivate.getFieldValue("f_testVar",
-        PrivateMemberClass.class, instance);
+    int ret = AccessPrivate.getFieldValue("f_testVar", PrivateMemberClass.class, instance);
     assertEquals(456, ret);
   }
 
@@ -62,8 +56,7 @@ public class AccessPrivateTest {
    */
   @Test
   public void privateStaticFieldAccessTest() {
-    Object ret = AccessPrivate.getFieldValue("f_staticTestVar",
-        PrivateMemberClass.class, null);
+    int ret = AccessPrivate.getFieldValue("f_staticTestVar", PrivateMemberClass.class, null);
     assertEquals(234, ret);
   }
 
@@ -76,7 +69,7 @@ public class AccessPrivateTest {
     String privateChangebleVar = "f_changeableTestVar";
     AccessPrivate.setFieldValue(privateChangebleVar,
         PrivateMemberClass.class, instance, -1);
-    assertEquals(-1, AccessPrivate.getFieldValue(privateChangebleVar,
+    assertEquals(-1, (int) AccessPrivate.getFieldValue(privateChangebleVar,
         PrivateMemberClass.class, instance));
   }
 
@@ -88,7 +81,7 @@ public class AccessPrivateTest {
     String privateChangebleVar = "f_changeableStaticTestVar";
     AccessPrivate.setFieldValue(privateChangebleVar,
         PrivateMemberClass.class, null, -2);
-    assertEquals(-2, AccessPrivate.getFieldValue(privateChangebleVar,
+    assertEquals(-2, (int) AccessPrivate.getFieldValue(privateChangebleVar,
         PrivateMemberClass.class, null));
   }
 
@@ -97,8 +90,7 @@ public class AccessPrivateTest {
    */
   @Test(expected = TestAnnotationException.class)
   public void setPrivateFinalFieldTest() {
-    AccessPrivate.setFieldValue("f_testVar", PrivateMemberClass.class,
-        null, -6);
+    AccessPrivate.setFieldValue("f_testVar", PrivateMemberClass.class, null, -6);
   }
 
   /**
@@ -106,7 +98,6 @@ public class AccessPrivateTest {
    */
   @Test(expected = TestAnnotationException.class)
   public void annotationExceptionTest() {
-    AccessPrivate.getFieldValue("NON_EXISTING_FIELD",
-        PrivateMemberClass.class, null);
+    AccessPrivate.getFieldValue("NON_EXISTING_FIELD", PrivateMemberClass.class, null);
   }
 }


### PR DESCRIPTION
It is now no longer necessary to cast the return values, as this is done with generics.
Example:
instead of :
`Color c5 = (Color)  AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 5, 10);`
you can now do:
`Color c5 =  AccessPrivate.callMethod("mapColor", NodeDensityHeatmap.class, null, 5, 10);`
or:
`Color c5 = AccessPrivate.<Color, NodeDensityHeatmap>callMethod("mapColor", NodeDensityHeatmap.class, null, 5, 10);`
This also applies to the getFieldValue method.

The types of the class and the passed object are now checked at compile time. If the given class does not correspond with the class of the given object, your code won't compile anymore.
