### PR TITLE
Update jdk for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: java
 jdk:
-        - oraclejdk8
+ - oraclejdk8
+
+# Use latest JDK, older version miss some JavaFX classes
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 
 env:
         # Source directory for the project
         - SRCDIR=PL2
 
 script: cd $SRCDIR && mvn verify
+


### PR DESCRIPTION
Some JavaFX classes are only available in newer versions, so travis needs to update prior building.
