### PR TITLE
Remove report-specific PMD configuration

### DIFF
--- a/PL2/pom.xml
+++ b/PL2/pom.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -63,13 +64,6 @@
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.6</version>
                 <configuration>
-                    <includeTests>true</includeTests>
-                    <minimumPriority>5</minimumPriority>
-                    <rulesets>
-                        <ruleset>rulesets/java/basic.xml</ruleset>
-                        <ruleset>rulesets/java/naming.xml</ruleset>
-                        <ruleset>rulesets/java/design.xml</ruleset>
-                    </rulesets>
                     <skipEmptyReport>false</skipEmptyReport>
                     <aggregate>true</aggregate>
                 </configuration>


### PR DESCRIPTION
Fixes: https://github.com/ProgrammingLife2016/PL2-2016/issues/62

This configuration was stricter than in the build goal. Making the build
goal was not possible (to my knowledge), so to synchronize the report
and build violations, the report had to be more lenient.
