### PR TITLE
Change API for lists in GraphNodes

### DIFF
--- a/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphs.java
+++ b/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphs.java
@@ -131,9 +131,9 @@ public class SplitGraphs {
       HashSet<GraphNode> nodeSet) {
     GraphNode newNode = original.copy();
 
-    pruneGenomes(original, genomeSet).forEach(newNode::addGenome);
-    newNode.setInEdges(pruneInLinks(original, nodeSet));
-    newNode.setOutEdges(pruneOutLinks(original, nodeSet));
+    newNode.addAllGenomes(pruneGenomes(original, genomeSet));
+    newNode.addAllInEdges(pruneInLinks(original, nodeSet));
+    newNode.addAllOutEdges(pruneOutLinks(original, nodeSet));
 
     return newNode;
   }

--- a/PL2/PL2-parser/src/main/java/nl/tudelft/pl2016gr2/parser/controller/GfaReader.java
+++ b/PL2/PL2-parser/src/main/java/nl/tudelft/pl2016gr2/parser/controller/GfaReader.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * This class reads a gfa file.
@@ -55,6 +56,7 @@ public class GfaReader {
         Logger.getLogger(GfaReader.class.getName()).log(Level.SEVERE, null, ex);
       }
       originalGraph = new HashGraph(nodes, GenomeMap.getInstance().copyAllGenomes());
+      originalGraph.iterator().forEachRemaining(GraphNode::trimToSize);
     }
     return originalGraph;
   }
@@ -171,7 +173,9 @@ public class GfaReader {
       }
       startIndex = index + 1;
     }
-    nodeGens.forEach((String genome) -> node.addGenome(GenomeMap.getInstance().getId(genome)));
+    node.addAllGenomes(
+        nodeGens.stream().map(genome -> GenomeMap.getInstance().getId(genome)).collect(
+            Collectors.toCollection(ArrayList::new)));
   }
 
   /**

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/GraphNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/GraphNode.java
@@ -96,35 +96,36 @@ public interface GraphNode extends Visitable, Copyable<GraphNode> {
   Collection<GraphNode> getInEdges();
 
   /**
-   * Sets the set of in-edges to be equal to the provided collection.
-   * <p>
-   * This method is a better performing abstraction of edge addition.
-   * This method should be used over {@link #addInEdge(int)} and {@link #removeInEdge(int)}
-   * wherever
-   * possible.
-   * </p>
-   * <p>
-   * The provided collection <b>may not</b> contain duplicates.
-   * These will not be removed by the method.
-   * </p>
-   *
-   * @param edges The collection of edges to make the in-edges of this node
-   */
-  void setInEdges(Collection<GraphNode> edges);
-
-  /**
    * Adds the specified ID to the set of in-edges of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
+   * <p>
+   * This method will have to expand the underlying data structure.
+   * Repeatedly adding edges should be done with {@link #addAllInEdges(Collection)}.
+   * </p>
    *
    * @param node The node to add to the in-edges of this <code>GraphNode</code>.
-   * @deprecated This method delivers suboptimal performance. Use {@link #setInEdges(Collection)}
    */
   void addInEdge(GraphNode node);
 
   /**
+   * Adds all edges to the current in edges, leaving the old in edges untouched.
+   * <p>
+   * This method ensures that storage is minimized after the additions.
+   * </p>
+   *
+   * @param nodes The nodes to add as in edges
+   */
+  void addAllInEdges(Collection<GraphNode> nodes);
+
+  /**
    * Removes the specified ID to the set of in-edges of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
    *
    * @param node The node to remove from the in-edges of this <code>GraphNode</code>.
-   * @deprecated This method delivers suboptimal performance. Use {@link #setInEdges(Collection)}
    */
   void removeInEdge(GraphNode node);
 
@@ -140,35 +141,36 @@ public interface GraphNode extends Visitable, Copyable<GraphNode> {
   Collection<GraphNode> getOutEdges();
 
   /**
-   * Sets the set of out-edges to be equal to the provided collection.
-   * <p>
-   * This method is a better performing abstraction of edge addition.
-   * This method should be used over {@link #addOutEdge(int)} and {@link #removeOutEdge(int)}
-   * wherever
-   * possible.
-   * </p>
-   * <p>
-   * The provided collection <b>may not</b> contain duplicates.
-   * These will not be removed by the method.
-   * </p>
-   *
-   * @param edges The collection of edges to make the out-edges of this node
-   */
-  void setOutEdges(Collection<GraphNode> edges);
-
-  /**
    * Adds the specified ID to the set of out-edges of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
+   * <p>
+   * This method will have to expand the underlying data structure.
+   * Repeatedly adding edges should be done with {@link #addAllOutEdges(Collection)}.
+   * </p>
    *
    * @param node The node to add to the out-edges of this <code>GraphNode</code>.
-   * @deprecated This method delivers suboptimal performance. Use {@link #setOutEdges(Collection)}
    */
   void addOutEdge(GraphNode node);
 
   /**
+   * Adds all edges to the current out edges, leaving the old out edges untouched.
+   * <p>
+   * This method ensures that storage is minimized after the additions.
+   * </p>
+   *
+   * @param nodes The nodes to add as out edges
+   */
+  void addAllOutEdges(Collection<GraphNode> nodes);
+
+  /**
    * Removes the specified ID to the set of out-edges of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
    *
    * @param node The node to remove from the out-edges of this <code>GraphNode</code>.
-   * @deprecated This method delivers suboptimal performance. Use {@link #setOutEdges(Collection)}
    */
   void removeOutEdge(GraphNode node);
 
@@ -189,13 +191,33 @@ public interface GraphNode extends Visitable, Copyable<GraphNode> {
 
   /**
    * Adds the genome name to the set of genomes of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
+   * <p>
+   * This method will have to expand the underlying data structure.
+   * Repeatedly adding genomes should be done with {@link #addAllGenomes(Collection)}.
+   * </p>
    *
    * @param genome The name of the genome to add to this <code>GraphNode</code>.
    */
   void addGenome(int genome);
 
   /**
+   * Adds all genomes to the current genomes, leaving the old genomes untouched.
+   * <p>
+   * This method ensures that storage is minimized after the additions.
+   * </p>
+   *
+   * @param genomes The genomes to add to this node
+   */
+  void addAllGenomes(Collection<Integer> genomes);
+
+  /**
    * Removes the genome name from the set of genomes of this <code>GraphNode</code>.
+   * <p>
+   * After calling this method, the caller must make sure to also call {@link #trimToSize()}.
+   * </p>
    *
    * @param genome The name of the genome to remove from this <code>GraphNode</code>.
    */
@@ -211,6 +233,14 @@ public interface GraphNode extends Visitable, Copyable<GraphNode> {
    * @return The set of genomes that pass over the common edge.
    */
   Collection<Integer> getGenomesOverEdge(GraphNode node);
+
+  /**
+   * Trims the capacity of this <code>GraphNode</code> instance to the currently used size.
+   * <p>
+   * This method can be used to minimize the storage of this <code>GraphNode</code>.
+   * </p>
+   */
+  void trimToSize();
 
   @Override
   default void accept(NodeVisitor visitor) {

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
@@ -55,6 +55,8 @@ public class SequenceNode extends AbstractNode {
     this.genomes = new ArrayList<>(genomes);
     inEdges = new ArrayList<>();
     outEdges = new ArrayList<>();
+
+    this.genomes.trimToSize();
   }
 
   /**
@@ -76,6 +78,8 @@ public class SequenceNode extends AbstractNode {
     this.genomes = new ArrayList<>(genomes);
     this.inEdges = new ArrayList<>(inEdges);
     this.outEdges = new ArrayList<>(outEdges);
+
+    this.genomes.trimToSize();
     this.inEdges.trimToSize();
     this.outEdges.trimToSize();
   }

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
@@ -99,16 +99,20 @@ public class SequenceNode extends AbstractNode {
   }
 
   @Override
-  public void setInEdges(Collection<GraphNode> edges) {
-    inEdges = new ArrayList<>(edges);
-    inEdges.trimToSize();
-  }
-
-  @Override
   public void addInEdge(GraphNode node) {
     assert !inEdges.contains(
         node) : "Adding existing in-edge: " + node.getId() + ". NodeID: " + this.getId();
     inEdges.add(node);
+  }
+
+  @Override
+  public void addAllInEdges(Collection<GraphNode> nodes) {
+    nodes.forEach(node -> {
+      assert !inEdges.contains(node);
+    });
+
+    inEdges.addAll(nodes);
+    inEdges.trimToSize();
   }
 
   @Override
@@ -124,16 +128,20 @@ public class SequenceNode extends AbstractNode {
   }
 
   @Override
-  public void setOutEdges(Collection<GraphNode> edges) {
-    outEdges = new ArrayList<>(edges);
-    outEdges.trimToSize();
-  }
-
-  @Override
   public void addOutEdge(GraphNode node) {
     assert !outEdges.contains(
         node) : "Adding existing out-edge: " + node.getId() + ". NodeID: " + this.getId();
     outEdges.add(node);
+  }
+
+  @Override
+  public void addAllOutEdges(Collection<GraphNode> nodes) {
+    nodes.forEach(node -> {
+      assert !outEdges.contains(node);
+    });
+
+    outEdges.addAll(nodes);
+    outEdges.trimToSize();
   }
 
   @Override
@@ -156,10 +164,27 @@ public class SequenceNode extends AbstractNode {
   }
 
   @Override
+  public void addAllGenomes(Collection<Integer> genomes) {
+    genomes.forEach(genome -> {
+      assert !this.genomes.contains(genome);
+    });
+
+    this.genomes.addAll(genomes);
+    this.genomes.trimToSize();
+  }
+
+  @Override
   public void removeGenome(int genome) {
     assert genomes.contains(
         genome) : "Removing non-existent genome: " + genome + ". NodeID: " + this.getId();
     genomes.remove(genome);
+  }
+
+  @Override
+  public void trimToSize() {
+    inEdges.trimToSize();
+    outEdges.trimToSize();
+    genomes.trimToSize();
   }
 
   @Override

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/SequenceNode.java
@@ -181,7 +181,7 @@ public class SequenceNode extends AbstractNode {
   public void removeGenome(int genome) {
     assert genomes.contains(
         genome) : "Removing non-existent genome: " + genome + ". NodeID: " + this.getId();
-    genomes.remove(genome);
+    genomes.remove((Integer) genome);
   }
 
   @Override

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceGraphTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceGraphTest.java
@@ -117,14 +117,25 @@ public class SequenceGraphTest {
   }
 
   @Test
-  public void removeGenome() {
-    int testGenome = 1;
-
+  public void removeGenomeRemovesElement() {
+    final int testGenome = 0;
     instance.addGenome(testGenome);
     assertTrue(instance.getGenomes().contains(testGenome));
 
     instance.removeGenome(testGenome);
+
     assertFalse(instance.getGenomes().contains(testGenome));
+  }
+
+  @Test
+  public void removeGenomeDoesNotRemoveByIndex() {
+    int outOfBounds = instance.getGenomes().size() + 25;
+    instance.addGenome(outOfBounds);
+    assertTrue(instance.getGenomes().contains(outOfBounds));
+
+    instance.removeGenome(outOfBounds);
+
+    assertFalse(instance.getGenomes().contains(outOfBounds));
   }
 
   @Test

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
@@ -343,13 +343,24 @@ public class SequenceNodeTest {
 
   @Test
   public void removeGenomeRemovesElement() {
-    final int testGenome = 0;
+    final int testGenome = 1;
     instance.addGenome(testGenome);
     assertTrue(instance.getGenomes().contains(testGenome));
 
     instance.removeGenome(testGenome);
 
     assertFalse(instance.getGenomes().contains(testGenome));
+  }
+
+  @Test
+  public void removeGenomeDoesNotRemoveByIndex() {
+    final int outOfBounds = instance.getGenomes().size() + 50;
+    instance.addGenome(outOfBounds);
+    assertTrue(instance.getGenomes().contains(outOfBounds));
+
+    instance.removeGenome(outOfBounds);
+
+    assertFalse(instance.getGenomes().contains(outOfBounds));
   }
 
   @Test

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
@@ -93,24 +93,9 @@ public class SequenceNodeTest {
   @Test
   public void getInEdges() {
     GraphNode mockedNode = mockNode(5, false);
-    instance.setInEdges(Collections.singletonList(mockedNode));
+    instance.addInEdge(mockedNode);
 
     assertTrue(instance.getInEdges().contains(mockedNode));
-  }
-
-  @Test
-  public void setInEdgesOverridePreviousElements() {
-    GraphNode mockedNode = mockNode(5, false);
-    instance.setInEdges(Collections.singletonList(mockedNode));
-    instance.setInEdges(Collections.singletonList(mockNode(10, false)));
-    assertFalse(instance.getInEdges().contains(mockedNode));
-  }
-
-  @Test
-  public void setInEdgesAddsAllElements() {
-    Collection<GraphNode> edgeList = Arrays.asList(mockNode(15, false), mockNode(45, false));
-    instance.setInEdges(edgeList);
-    assertTrue(instance.getInEdges().containsAll(edgeList));
   }
 
   @Test
@@ -126,10 +111,49 @@ public class SequenceNodeTest {
   @Test
   public void addInEdgeDoesNotOverrideOldElements() {
     GraphNode mockedNode = mockNode(5, false);
-    instance.setInEdges(Collections.singletonList(mockedNode));
+    instance.addInEdge(mockedNode);
     instance.addInEdge(mockNode(10, false));
 
     assertTrue(instance.getInEdges().contains(mockedNode));
+  }
+
+  @Test
+  public void addAllInEdgesAddsAllEdges() {
+    GraphNode nodeOne = mockNode(1, false);
+    GraphNode nodeTwo = mockNode(2, false);
+    assertFalse(instance.getInEdges().contains(nodeOne));
+    assertFalse(instance.getInEdges().contains(nodeTwo));
+
+    instance.addAllInEdges(Arrays.asList(nodeOne, nodeTwo));
+
+    assertTrue(instance.getInEdges().contains(nodeOne));
+    assertTrue(instance.getInEdges().contains(nodeTwo));
+  }
+
+  @Test
+  public void addAllInEdgesLeavesOldEdges() {
+    GraphNode oldNode = mockNode(10, false);
+    GraphNode node = new SequenceNode(5, mock(BaseSequence.class), Collections.emptyList(),
+        Collections.singletonList(oldNode), Collections.emptyList());
+
+    assertTrue(node.getInEdges().contains(oldNode));
+    GraphNode newNode = mockNode(2, false);
+
+    node.addAllInEdges(Collections.singletonList(newNode));
+
+    assertTrue(node.getInEdges().contains(oldNode));
+  }
+
+  @Test
+  public void addAllInEdgesAddsOnlyEdges() {
+    final int edgeCount = instance.getInEdges().size();
+
+    GraphNode nodeOne = mockNode(1, false);
+    GraphNode nodeTwo = mockNode(2, false);
+
+    instance.addAllInEdges(Arrays.asList(nodeOne, nodeTwo));
+
+    assertEquals(edgeCount + 2, instance.getInEdges().size());
   }
 
   @Test
@@ -145,7 +169,7 @@ public class SequenceNodeTest {
   @Test
   public void removeInEdgeLeavesOtherElements() {
     GraphNode mockedNode = mockNode(5, false);
-    instance.setInEdges(Collections.singletonList(mockedNode));
+    instance.addInEdge(mockedNode);
 
     instance.addInEdge(mockNode(10, true));
 
@@ -160,24 +184,9 @@ public class SequenceNodeTest {
   @Test
   public void getOutEdges() {
     GraphNode mockedNode = mockNode(5, false);
-    instance.setOutEdges(Collections.singletonList(mockedNode));
+    instance.addOutEdge(mockedNode);
 
     assertTrue(instance.getOutEdges().contains(mockedNode));
-  }
-
-  @Test
-  public void setOutEdgesOverridePreviousElements() {
-    GraphNode mockedNode = mockNode(5, false);
-    instance.setOutEdges(Collections.singletonList(mockedNode));
-    instance.setOutEdges(Arrays.asList(mockNode(10, false), mockNode(12, false)));
-    assertFalse(instance.getOutEdges().contains(mockedNode));
-  }
-
-  @Test
-  public void setOutEdgesAddsAllElements() {
-    Collection<GraphNode> edgeList = Arrays.asList(mockNode(5, false), mockNode(10, true));
-    instance.setOutEdges(edgeList);
-    assertTrue(instance.getOutEdges().containsAll(edgeList));
   }
 
   @Test
@@ -194,10 +203,49 @@ public class SequenceNodeTest {
   @Test
   public void addOutEdgeDoesNotOverrideOldElements() {
     GraphNode mockedNode = mockNode(10, false);
-    instance.setOutEdges(Collections.singletonList(mockedNode));
+    instance.addOutEdge(mockedNode);
     instance.addOutEdge(mockNode(12, true));
 
     assertTrue(instance.getOutEdges().contains(mockedNode));
+  }
+
+  @Test
+  public void addAllOutEdgesAddsAllEdges() {
+    GraphNode nodeOne = mockNode(1, false);
+    GraphNode nodeTwo = mockNode(2, false);
+    assertFalse(instance.getOutEdges().contains(nodeOne));
+    assertFalse(instance.getOutEdges().contains(nodeTwo));
+
+    instance.addAllOutEdges(Arrays.asList(nodeOne, nodeTwo));
+
+    assertTrue(instance.getOutEdges().contains(nodeOne));
+    assertTrue(instance.getOutEdges().contains(nodeTwo));
+  }
+
+  @Test
+  public void addAllOutEdgesLeavesOldEdges() {
+    GraphNode oldNode = mockNode(10, false);
+    GraphNode node = new SequenceNode(5, mock(BaseSequence.class), Collections.emptyList(),
+        Collections.emptyList(), Collections.singletonList(oldNode));
+
+    assertTrue(node.getOutEdges().contains(oldNode));
+    GraphNode newNode = mockNode(2, false);
+
+    node.addAllOutEdges(Collections.singletonList(newNode));
+
+    assertTrue(node.getOutEdges().contains(oldNode));
+  }
+
+  @Test
+  public void addAllOutEdgesAddsOnlyEdges() {
+    final int edgeCount = instance.getOutEdges().size();
+
+    GraphNode nodeOne = mockNode(1, false);
+    GraphNode nodeTwo = mockNode(2, false);
+
+    instance.addAllOutEdges(Arrays.asList(nodeOne, nodeTwo));
+
+    assertEquals(edgeCount + 2, instance.getOutEdges().size());
   }
 
   @Test
@@ -214,7 +262,7 @@ public class SequenceNodeTest {
   public void removeOutEdgeLeavesOtherElements() {
     GraphNode mockedNode = mockNode(5, false);
     GraphNode removeNode = mockNode(10, true);
-    instance.setOutEdges(Arrays.asList(mockedNode, removeNode));
+    instance.addAllOutEdges(Arrays.asList(mockedNode, removeNode));
 
     instance.removeOutEdge(removeNode);
 
@@ -259,6 +307,41 @@ public class SequenceNodeTest {
   }
 
   @Test
+  public void addAllGenomesAddsAllGenomes() {
+    final int genomeOne = 50;
+    final int genomeTwo = 60;
+    assertFalse(instance.getGenomes().contains(genomeOne));
+    assertFalse(instance.getGenomes().contains(genomeTwo));
+
+    instance.addAllGenomes(Arrays.asList(genomeOne, genomeTwo));
+
+    assertTrue(instance.getGenomes().contains(genomeOne));
+    assertTrue(instance.getGenomes().contains(genomeTwo));
+  }
+
+  @Test
+  public void addAllGenomesAddsLeavesOldGenomes() {
+    final int oldGenome = 50;
+    final int newGenome = 60;
+    GraphNode node = new SequenceNode(5, mock(BaseSequence.class),
+        Collections.singletonList(oldGenome), Collections.emptyList(), Collections.emptyList());
+    assertTrue(node.getGenomes().contains(oldGenome));
+
+    node.addAllGenomes(Collections.singletonList(newGenome));
+
+    assertTrue(node.getGenomes().contains(oldGenome));
+  }
+
+  @Test
+  public void addAllGenomesAddsOnlyGenomes() {
+    final int genomeCount = instance.getGenomes().size();
+
+    instance.addAllGenomes(Arrays.asList(50, 60));
+
+    assertEquals(genomeCount + 2, instance.getGenomes().size());
+  }
+
+  @Test
   public void removeGenomeRemovesElement() {
     final int testGenome = 0;
     instance.addGenome(testGenome);
@@ -289,6 +372,25 @@ public class SequenceNodeTest {
   }
 
   @Test
+  public void trimToSizeTrimsGenomeMemory() {
+    for (int i = 0; i < 1000; i++) {
+      instance.addGenome(i);
+    }
+    for (int i = 0; i < 1000; i++) {
+      instance.removeGenome(i);
+    }
+    System.gc();
+    Runtime runtime = Runtime.getRuntime();
+    long oldMemory = runtime.totalMemory() - runtime.freeMemory();
+
+    instance.trimToSize();
+    System.gc();
+
+    long newMemory = runtime.totalMemory() - runtime.freeMemory();
+    assertTrue(newMemory < oldMemory);
+  }
+
+  @Test
   public void copy() {
     Class old = instance.getClass();
     assertEquals(old, instance.copy().getClass());
@@ -308,7 +410,7 @@ public class SequenceNodeTest {
 
   @Test
   public void isRootFalseWhenNotRoot() {
-    instance.setInEdges(Collections.singletonList(mockNode(10, false)));
+    instance.addInEdge(mockNode(20, false));
     assertFalse(instance.isRoot());
   }
 


### PR DESCRIPTION
The lists can now be trimmed.

I deprecated the setter methods for edges. There is no need for them now with the `addAll` methods (which do the same without replacing the list reference inside the node).

I also found a bug in the `removeGenome` method: it removed genomes per index (introduced when switching from genome strings to genome integers).

I also added the trimming actions to all `SequenceNode` constructors, because it was missing in some cases.
