### PR TITLE
Fix SplitGraphs bug

### DIFF
--- a/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphs.java
+++ b/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphs.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 /**
@@ -36,9 +35,8 @@ public class SplitGraphs {
   /**
    * Instantiates an algorithmic class on a <code>SequenceGraph</code>.
    * <p>
-   * When {@link #getSubgraph(Collection)} is called, the class will construct a new instance of
-   * the
-   * graph containing only the specified genomes.
+   * When {@link #getSubgraph(Collection)} is called, this class will construct a new instance of
+   * the graph containing only the specified genomes.
    * </p>
    *
    * @param mainGraph The graph to split
@@ -62,9 +60,7 @@ public class SplitGraphs {
     assert mainGraph.getGenomes().containsAll(
         genomeSet) : "Tried splitting graph on absent genomes";
 
-    HashSet<GraphNode> nodeSet = findSubgraphNodes(genomeSet);
-    HashMap<Integer, GraphNode> nodeMap = new HashMap<>();
-    nodeSet.forEach(node -> nodeMap.put(node.getId(), node));
+    HashMap<Integer, GraphNode> nodeMap = findSubgraphNodes(genomeSet);
     return createNewGraph(nodeMap, genomeSet);
   }
 
@@ -77,68 +73,63 @@ public class SplitGraphs {
    * @param genomeSet the genomes that should be included in the subgraph.
    * @return a map containing all of the nodes which are part of the subgraph.
    */
-  private HashSet<GraphNode> findSubgraphNodes(HashSet<Integer> genomeSet) {
-    HashSet<GraphNode> nodeSet = new HashSet<>();
-    Iterator<GraphNode> nodeIterator = mainGraph.iterator();
-    nodeIterator.forEachRemaining(node -> {
-      for (int genome : node.getGenomes()) {
-        if (genomeSet.contains(genome)) {
-          nodeSet.add(node);
-          break;
-        }
+  private HashMap<Integer, GraphNode> findSubgraphNodes(HashSet<Integer> genomeSet) {
+    HashMap<Integer, GraphNode> nodeMap = new HashMap<>();
+    mainGraph.forEach(node -> {
+      if (node.getGenomes().stream().anyMatch(genomeSet::contains)) {
+        nodeMap.put(node.getId(), node);
       }
     });
-    return nodeSet;
+    assert !nodeMap.isEmpty() : "Subgraph returned zero nodes. This is impossible at this stage";
+    return nodeMap;
   }
 
   /**
-   * Create a new graph, containing all of the nodes in the node map with the correct in/out links
+   * Create a new graph, containing copies of all the nodes in the node map with the correct in/out
+   * links
    * and genome lists.
    * <p>
    * This operation is performed in <code>O(n)</code> for <code>n</code> nodes. This method
-   * requires
-   * a {@link HashSet} to provide this time complexity.
+   * requires a {@link HashSet} to provide this time complexity.
    * </p>
    *
-   * @param nodeSet   The set containing the original nodes which are contained in the subgraph.
-   * @param genomeSet The set of all genomes that should be included in the subgraph.
+   * @param oldNodes The set containing the original nodes which are contained in the subgraph.
+   * @param genomes  The set of all genomes that should be included in the subgraph.
    * @return the new graph which contains all of the newly created nodes.
    */
-  private SequenceGraph createNewGraph(HashMap<Integer, GraphNode> nodeSet, HashSet<Integer> genomeSet) {
+  private SequenceGraph createNewGraph(HashMap<Integer, GraphNode> oldNodes,
+      HashSet<Integer> genomes) {
     HashMap<Integer, GraphNode> newNodes = new HashMap<>();
 
-    nodeSet.forEach((id, originalNode) -> {
-      GraphNode newNode = pruneNode(originalNode, genomeSet);
-      newNodes.put(id, newNode);
-    });
-    newNodes.forEach((id, node) -> {
-      node.addAllInEdges(pruneInLinks(node, newNodes, nodeSet));
-      node.addAllOutEdges(pruneOutLinks(node, newNodes, nodeSet));
-    });
-    return new HashGraph(newNodes, genomeSet);
+    oldNodes.forEach((id, originalNode) -> newNodes.put(id, originalNode.copy()));
+    HashMap<Integer, GraphNode> prunedNodes = pruneNodes(newNodes, oldNodes, genomes);
+    return new HashGraph(prunedNodes, genomes);
   }
 
   /**
-   * Creates a copy of the <code>original</code> node and prunes irrelevant fields.
+   * Prunes irrelevant fields of the original nodes and applies them to the new nodes.
    * <p>
-   * The method returns a newly instantiated {@link GraphNode} object that is identical, except for
-   * the genomes, in-edges and out-edges.
+   * This method returns the same <code>newNodes</code> map, with all nodes updated correctly.
    * </p>
    * <p>
-   * This operation is performed in <code>O(l+m)</code> for <code>l, m</code> genomes and links
-   * respectively.
+   * This operation is performed in <code>O(n*(k+l+m)</code> for <code>n</code> nodes and <code>k,
+   * l, m</code> genomes, in edges and out edges respectively.
    * </p>
    *
-   * @param original  The original <code>node</code> to prune and copy
-   * @param genomeSet The set of genomes that should be retained in the pruning process
-   * @return A new <code>GraphNode</code> identical to the <code>original</code> after pruning
+   * @param newNodes The new nodes to apply the pruned data to
+   * @param oldNodes The original <code>node</code>s whose data to prune
+   * @param genomes  The set of genomes that should be retained in the pruning process
+   * @return The updated map of nodes
    */
-  private GraphNode pruneNode(GraphNode original, HashSet<Integer> genomeSet) {
-    GraphNode newNode = original.copy();
+  private HashMap<Integer, GraphNode> pruneNodes(HashMap<Integer, GraphNode> newNodes,
+      HashMap<Integer, GraphNode> oldNodes, HashSet<Integer> genomes) {
+    newNodes.forEach((id, node) -> {
+      node.addAllInEdges(pruneInEdges(node, newNodes, oldNodes, genomes));
+      node.addAllOutEdges(pruneOutEdges(node, newNodes, oldNodes, genomes));
+      node.addAllGenomes(pruneGenomes(oldNodes.get(id), genomes));
+    });
 
-    newNode.addAllGenomes(pruneGenomes(original, genomeSet));
-
-    return newNode;
+    return newNodes;
   }
 
   /**
@@ -148,19 +139,25 @@ public class SplitGraphs {
    * This operation is performed in <code>O(m)</code> for <code>m</code> inLinks.
    * </p>
    *
-   * @param original   The node to build the subset for
+   * @param newNode  The node to build the subset for
+   * @param newNodes The nodes of the new graph
+   * @param oldNodes The nodes of the old graph
    * @return The intersection of the node inLinks and the graph nodes
    */
-  private Collection<GraphNode> pruneInLinks(GraphNode original, HashMap<Integer, GraphNode> graph,
-      HashMap<Integer, GraphNode> nodeSet) {
-    Collection<GraphNode> prunedInLinks = new ArrayList<>();
-    nodeSet.get(original.getId()).getInEdges().forEach(edge -> {
-      GraphNode fromNode = graph.get(edge.getId());
-      if (fromNode != null) {
-        prunedInLinks.add(fromNode);
+  private Collection<GraphNode> pruneInEdges(GraphNode newNode,
+      HashMap<Integer, GraphNode> newNodes, HashMap<Integer, GraphNode> oldNodes,
+      Collection<Integer> genomes) {
+    Collection<GraphNode> prunedInEdges = new ArrayList<>();
+    GraphNode oldNode = oldNodes.get(newNode.getId());
+    oldNode.getInEdges().forEach(oldInEdge -> {
+      if (oldInEdge.getGenomesOverEdge(oldNode).stream().anyMatch(genomes::contains)) {
+        // Edge is valid
+        GraphNode newInEdge = newNodes.get(oldInEdge.getId());
+        assert newInEdge != null;
+        prunedInEdges.add(newInEdge);
       }
     });
-    return prunedInLinks;
+    return prunedInEdges;
   }
 
   /**
@@ -171,19 +168,25 @@ public class SplitGraphs {
    * This operation is performed in <code>O(m)</code> for <code>m</code> outLinks.
    * </p>
    *
-   * @param original   The node to build the subset for
-   * @return The intersection of the node outLinks and the graph nodes
+   * @param newNode  The node to build the subset for
+   * @param newNodes The nodes of the new graph
+   * @param oldNodes The nodes of the old graph
+   * @return The intersection of the node outLinks and the subgraph nodes
    */
-  private Collection<GraphNode> pruneOutLinks(GraphNode original, HashMap<Integer, GraphNode> graph,
-      HashMap<Integer, GraphNode> nodeSet) {
-    Collection<GraphNode> prunedOutLinks = new ArrayList<>();
-    nodeSet.get(original.getId()).getOutEdges().forEach(edge -> {
-      GraphNode toNode = graph.get(edge.getId());
-      if (toNode != null) {
-        prunedOutLinks.add(toNode);
+  private Collection<GraphNode> pruneOutEdges(GraphNode newNode,
+      HashMap<Integer, GraphNode> newNodes, HashMap<Integer, GraphNode> oldNodes,
+      Collection<Integer> genomes) {
+    Collection<GraphNode> prunedOutEdges = new ArrayList<>();
+    GraphNode oldNode = oldNodes.get(newNode.getId());
+    oldNode.getOutEdges().forEach(outEdge -> {
+      if (oldNode.getGenomesOverEdge(outEdge).stream().anyMatch(genomes::contains)) {
+        // Edge is valid
+        GraphNode newOutEdge = newNodes.get(outEdge.getId());
+        assert newOutEdge != null;
+        prunedOutEdges.add(newOutEdge);
       }
     });
-    return prunedOutLinks;
+    return prunedOutEdges;
   }
 
   /**

--- a/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
+++ b/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
@@ -42,7 +42,7 @@ public class SplitGraphsTest {
   private SequenceGraph mockedGraph;
   private ArrayList<Integer> genomeSet;
   private SplitGraphs defInstance;
-  private HashMap<Integer, SequenceNode> nodes;
+  private HashMap<Integer, GraphNode> nodes;
 
   /**
    * Sets up mocked dependencies.

--- a/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
+++ b/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
@@ -331,6 +331,39 @@ public class SplitGraphsTest {
     });
   }
 
+  @Test
+  @SuppressWarnings("checkstyle:methodlength")
+  public void testGetSubGraphCreatesNewNodes() {
+    // Mock the graph
+    int genomeOne = 1;
+    int genomeTwo = 2;
+    GraphNode zero = mockGraphNode(
+        new Integer[] {genomeOne, genomeTwo}, new Integer[] {}, new Integer[] {}, 0);
+    GraphNode one = mockGraphNode(new Integer[] {genomeOne}, new Integer[] {}, new Integer[] {}, 1);
+    GraphNode two = mockGraphNode(
+        new Integer[] {genomeOne, genomeTwo}, new Integer[] {}, new Integer[] {}, 2);
+
+    zero.addAllInEdges(Collections.emptyList());
+    zero.addAllOutEdges(Arrays.asList(one, two));
+    one.addAllInEdges(Collections.singletonList(zero));
+    one.addAllOutEdges(Collections.singletonList(two));
+    two.addAllInEdges(Arrays.asList(zero, one));
+    two.addAllOutEdges(Collections.emptyList());
+
+    Map<Integer, GraphNode> nodes = new HashMap<>();
+    nodes.put(0, zero);
+    nodes.put(1, one);
+    nodes.put(2, two);
+    SequenceGraph graph = new HashGraph(
+        nodes, Collections.singletonList(zero), Arrays.asList(genomeOne, genomeTwo));
+
+    // Instrument the sub graph
+    SplitGraphs splitGraph = new SplitGraphs(graph);
+    SequenceGraph subGraph = splitGraph.getSubgraph(Collections.singletonList(1));
+
+    subGraph.forEach(node -> assertFalse(nodes.get(node.getId()) == node));
+  }
+
   /**
    * Stubs the forEachRemaining method by applying the lambda to every element in the iterator.
    * <p>

--- a/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
+++ b/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
@@ -72,7 +72,8 @@ public class SplitGraphsTest {
 
     when(mockedIterator.hasNext()).thenReturn(true, true, true, false);
     when(mockedIterator.next()).thenReturn(firstNode, secondNode, thirdNode);
-    doAnswer(new ForEachAnswer()).when(mockedIterator).forEachRemaining(any());
+    doAnswer(new ForEachRemainingAnswer()).when(mockedIterator).forEachRemaining(any());
+    doAnswer(new ForEachAnswer()).when(mockedGraph).forEach(any());
     when(mockedGraph.iterator()).thenReturn(mockedIterator);
     when(mockedGraph.getNode(0)).thenReturn(firstNode);
     when(mockedGraph.getNode(1)).thenReturn(secondNode);
@@ -315,7 +316,7 @@ public class SplitGraphsTest {
 
     graph.forEach(node -> assertTrue(subGraph.contains(node)));
 
-    graph.forEach(node -> {
+    subGraph.forEach(node -> {
       if (node.getId() == 0) {
         assertFalse(node.getOutEdges().contains(two));
         assertTrue(node.getOutEdges().contains(one));
@@ -370,7 +371,7 @@ public class SplitGraphsTest {
    * Requires correct stubbing of the <code>next()</code> and <code>hasNext()</code> methods.
    * </p>
    */
-  private static class ForEachAnswer implements Answer<Void> {
+  private static class ForEachRemainingAnswer implements Answer<Void> {
 
     @Override
     @SuppressWarnings("unchecked") // Necessary to cast the InvocationOnMock types.
@@ -379,6 +380,28 @@ public class SplitGraphsTest {
       Consumer<GraphNode> arg = (Consumer<GraphNode>) invocationOnMock.getArguments()[0];
       while (invocation.hasNext()) {
         arg.accept(invocation.next());
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Stubs the forEach method in a Graph by applying the lambda to every element in its iterator.
+   * <p>
+   * Requires correct stubbing of the <code>next()</code> and <code>hasNext()</code> methods,
+   * as well as the <code>iterator()</code> method.
+   * </p>
+   */
+  private static class ForEachAnswer implements Answer<Void> {
+
+    @Override
+    @SuppressWarnings("unchecked") // Necessary to cast the InvocationOnMock types.
+    public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+      SequenceGraph invocation = (SequenceGraph) invocationOnMock.getMock();
+      Consumer<GraphNode> arg = (Consumer<GraphNode>) invocationOnMock.getArguments()[0];
+      Iterator<GraphNode> graphIterator = invocation.iterator();
+      while (graphIterator.hasNext()) {
+        arg.accept(graphIterator.next());
       }
       return null;
     }

--- a/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
+++ b/PL2/PL2-core/src/test/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SplitGraphsTest.java
@@ -96,7 +96,7 @@ public class SplitGraphsTest {
       outLinkNodes.add(mockNode(outLink, false));
     }
     return new SequenceNode(identifier, new BaseSequence("ACTG"), Arrays.asList(genomes),
-        inLinkNodes, inLinkNodes);
+        inLinkNodes, outLinkNodes);
   }
 
   @Test

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/AbstractNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/AbstractNode.java
@@ -61,8 +61,17 @@ public abstract class AbstractNode implements Node {
         + "a" + " direct successor. This = " + this.getId();
 
     Collection<Integer> genomes = new ArrayList<>();
-    getGenomes().stream().filter(genome -> node.getGenomes().contains(genome)).forEach(genomes
-        ::add);
+    Collection<Integer> otherGenomes = new ArrayList<>();
+    // Mark genomes that are seen in other out edges which appear before the node.
+    this.getOutEdges().forEach(outEdge -> {
+      if (!outEdge.equals(node) && outEdge.getId() < node.getId()) {
+        otherGenomes.addAll(outEdge.getGenomes());
+      }
+    });
+    getGenomes().stream().filter(
+        genome -> node.getGenomes().contains(genome) && !otherGenomes.contains(genome)).forEach(
+        genomes::add);
+
     return genomes;
   }
 

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/AbstractNodeTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/AbstractNodeTest.java
@@ -15,6 +15,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 /**
@@ -84,8 +85,61 @@ public class AbstractNodeTest {
     Mockito.when(otherNode.getInEdges()).thenReturn(Collections.singletonList(instance));
     Mockito.when(instance.getOutEdges()).thenReturn(Collections.singletonList(otherNode));
 
-    assertTrue(instance.getGenomesOverEdge(otherNode).contains(1));
+    Collection<Integer> genomesOverEdge = instance.getGenomesOverEdge(otherNode);
+    assertTrue(genomesOverEdge.contains(1));
+    assertFalse(genomesOverEdge.contains(2));
+    assertFalse(genomesOverEdge.contains(5));
     assertEquals(1, instance.getGenomesOverEdge(otherNode).size());
+  }
+
+  @Test
+  public void getGenomesOverEdgeDoesNotReturnLongerPaths() {
+    GraphNode otherNode = mock(GraphNode.class);
+    GraphNode inBetweenNode = mock(GraphNode.class);
+
+    Mockito.when(otherNode.getId()).thenReturn(2);
+    Mockito.when(inBetweenNode.getId()).thenReturn(1);
+    AccessPrivate.setFieldValue("id_field", AbstractNode.class, instance, 5);
+
+    Mockito.when(instance.getGenomes()).thenReturn(Arrays.asList(1, 2, 3));
+    Mockito.when(inBetweenNode.getGenomes()).thenReturn(Arrays.asList(1, 3));
+    Mockito.when(otherNode.getGenomes()).thenReturn(Arrays.asList(1, 2, 3));
+
+    Mockito.when(otherNode.getInEdges()).thenReturn(Arrays.asList(instance, inBetweenNode));
+    Mockito.when(inBetweenNode.getInEdges()).thenReturn(Collections.singletonList(instance));
+    Mockito.when(inBetweenNode.getOutEdges()).thenReturn(Collections.singletonList(otherNode));
+    Mockito.when(instance.getOutEdges()).thenReturn(Arrays.asList(inBetweenNode, otherNode));
+
+    Collection<Integer> genomesOverEdge = instance.getGenomesOverEdge(otherNode);
+
+    assertTrue(!genomesOverEdge.contains(1));
+    assertTrue(genomesOverEdge.contains(2));
+    assertEquals(1, genomesOverEdge.size());
+  }
+
+  @Test
+  public void getGenomesOverEdgeDoesNotReturnLongerPathsBackwards() {
+    GraphNode otherNode = mock(GraphNode.class);
+    GraphNode startNode = mock(GraphNode.class);
+
+    Mockito.when(otherNode.getId()).thenReturn(2);
+    Mockito.when(startNode.getId()).thenReturn(1);
+    AccessPrivate.setFieldValue("id_field", AbstractNode.class, instance, 5);
+
+    Mockito.when(instance.getGenomes()).thenReturn(Arrays.asList(1, 3));
+    Mockito.when(startNode.getGenomes()).thenReturn(Arrays.asList(1, 2, 3));
+    Mockito.when(otherNode.getGenomes()).thenReturn(Arrays.asList(1, 2, 3));
+
+    Mockito.when(otherNode.getInEdges()).thenReturn(Arrays.asList(instance, startNode));
+    Mockito.when(instance.getInEdges()).thenReturn(Collections.singletonList(instance));
+    Mockito.when(instance.getOutEdges()).thenReturn(Collections.singletonList(otherNode));
+    Mockito.when(startNode.getOutEdges()).thenReturn(Arrays.asList(startNode, otherNode));
+
+    Collection<Integer> genomesOverEdge = instance.getGenomesOverEdge(otherNode);
+
+    assertTrue(!genomesOverEdge.contains(2));
+    assertTrue(genomesOverEdge.containsAll(Arrays.asList(1, 3)));
+    assertEquals(2, genomesOverEdge.size());
   }
 
   @Test

--- a/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
+++ b/PL2/PL2-shared/src/test/java/nl/tudelft/pl2016gr2/model/SequenceNodeTest.java
@@ -402,9 +402,29 @@ public class SequenceNodeTest {
   }
 
   @Test
-  public void copy() {
+  public void testCopyClass() {
     Class old = instance.getClass();
     assertEquals(old, instance.copy().getClass());
+  }
+
+  @Test
+  public void testCopyShouldCopyId() {
+    assertEquals(instance.getId(), instance.copy().getId());
+  }
+
+  @Test
+  public void testCopyShouldNotCopyGenomes() {
+    assertTrue(instance.copy().getGenomes().isEmpty());
+  }
+
+  @Test
+  public void testCopyShouldNotCopyInEdges() {
+    assertTrue(instance.copy().getInEdges().isEmpty());
+  }
+
+  @Test
+  public void testCopyShouldNotCopyOutEdges() {
+    assertTrue(instance.copy().getOutEdges().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Fixes the bug of drawing too many lines for the subset of genomes.

See #169.

To fix this, I corrected the `getGenomesOverEdge` method. This method was rather an estimate than the exact genomes, which I did need however for the SplitGraphs algorithm to select the right edges.

Right now, the method uses IDs, but a more solid value should be used (such as `getLevel()`). This can be done as soon as the semantic branch has been merged.

A ticket for this can be found here: #186
