### PR TITLE
Drag all genomes in selection from search pane

### DIFF
--- a/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/SearchPaneController.java
+++ b/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/SearchPaneController.java
@@ -134,8 +134,15 @@ public class SearchPaneController implements Initializable {
       TableRow<Annotation> row = new TableRow<>();
 
       row.setOnDragDetected((MouseEvent event) -> {
+        // Format the genome selection for dragging
+        StringBuilder genomeStringBuilder = new StringBuilder();
+        for (int genome : selectionManager.getSearchBoxSelectedGenomes()) {
+          genomeStringBuilder.append(GenomeMap.getInstance().getGenome(genome)).append('\n');
+        }
+        genomeStringBuilder.deleteCharAt(genomeStringBuilder.length() - 1);
+
         ClipboardContent clipboard = new ClipboardContent();
-        clipboard.putString(row.getItem().specimenId);
+        clipboard.putString(genomeStringBuilder.toString());
         Dragboard dragboard = row.startDragAndDrop(TransferMode.ANY);
         dragboard.setContent(clipboard);
 


### PR DESCRIPTION
Before, only one of the genomes (the current row) was dragged.
