### PR TITLE
Show ellipses for SequenceNode when too long

### DIFF
--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/SequenceNode.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/SequenceNode.java
@@ -171,7 +171,7 @@ public class SequenceNode extends AbstractGraphNode implements Node {
   public String toString() {
     String sequenceString = getSequence();
     if (sequenceString.length() > 20) {
-      sequenceString = sequenceString.substring(0, 20);
+      sequenceString = String.format("%s...", sequenceString.substring(0, 20));
     }
     return String.format("Sequence %d:\n%s\n", getId(), sequenceString);
   }


### PR DESCRIPTION
The ellipses were missing and thus it wouldn't be visible that the sequence is actually longer.
