### PR TITLE
Fixed 2 edge bugs

### DIFF
--- a/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/graph/GraphPaneController.java
+++ b/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/graph/GraphPaneController.java
@@ -951,14 +951,12 @@ public class GraphPaneController implements Initializable {
       if (!node.isPopped()) {
         for (GraphNode outEdge : node.getOutEdges()) {
           double edgeWidth = calculateEdgeWidth(genomeCount, node, outEdge);
-          drawEdge(canvas.getGraphicsContext2D(), node, outEdge, edgeWidth, startLevel,
-              node.getGuiData().range, outEdge.getGuiData().range);
+          drawEdge(canvas.getGraphicsContext2D(), node, outEdge, edgeWidth, startLevel);
         }
         for (GraphNode inEdge : node.getInEdges()) {
           if (!drawnGraphNodes.contains(inEdge)) {
             double edgeWidth = calculateEdgeWidth(genomeCount, inEdge, node);
-            drawEdge(canvas.getGraphicsContext2D(), inEdge, node, edgeWidth, startLevel,
-                node.getGuiData().range, inEdge.getGuiData().range);
+            drawEdge(canvas.getGraphicsContext2D(), inEdge, node, edgeWidth, startLevel);
           }
         }
       }
@@ -973,10 +971,10 @@ public class GraphPaneController implements Initializable {
    * @param toNode         the node to draw the edge to.
    * @param edgeWidth      the width of the edge.
    * @param startLevel     the start level: where to start drawing.
-   * @param viewRange      the range of values which may be used as y coordinate to draw this edge.
    */
+  @SuppressWarnings("checkstyle:MethodLength")
   private void drawEdge(GraphicsContext graphicContext, GraphNode fromNode, GraphNode toNode,
-      double edgeWidth, double startLevel, GraphViewRange fromRange, GraphViewRange toRange) {
+      double edgeWidth, double startLevel) {
     graphicContext.setLineWidth(edgeWidth * 2);
     double startX;
     if (fromNode.hasChildren()) {
@@ -991,6 +989,8 @@ public class GraphPaneController implements Initializable {
     } else {
       endX = zoomFactor.get() * (toNode.getLevel() - startLevel - toNode.size() * HALF_NODE_MARGIN);
     }
+    GraphViewRange fromRange = fromNode.getGuiData().range;
+    GraphViewRange toRange = toNode.getGuiData().range;
     double startY = fromNode.getGuiData().relativeYPos * fromRange.rangeHeight
         + fromRange.rangeStartY;
     double endY = toNode.getGuiData().relativeYPos * toRange.rangeHeight + toRange.rangeStartY;

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/AbstractGraphBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/AbstractGraphBubble.java
@@ -87,6 +87,9 @@ public abstract class AbstractGraphBubble extends Bubble {
 
   @Override
   public void unpop() {
+    for (GraphNode child : getChildren()) {
+      child.unpop();
+    }
     if (isPopped) {
       isPopped = false;
       for (GraphNode node : getInEdges()) {

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/IndelBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/IndelBubble.java
@@ -75,6 +75,9 @@ public class IndelBubble extends Bubble {
 
   @Override
   public void unpop() {
+    for (GraphNode child : getChildren()) {
+      child.unpop();
+    }
     if (isPopped) {
       setUnpoppedEdges();
       isPopped = false;

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/StraightSequenceBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/StraightSequenceBubble.java
@@ -68,6 +68,9 @@ public class StraightSequenceBubble extends Bubble {
 
   @Override
   public void unpop() {
+    for (GraphNode child : getChildren()) {
+      child.unpop();
+    }
     if (isPopped) {
       setUnpoppedEdges();
       isPopped = false;


### PR DESCRIPTION
Fixes #233

Bug 1: Now when bubbles are unpopped, the nested bubbles are forced to be unpopped as well.
Bug 2: The y coordinate of the edge origin and destination aren't swapped anymore when the origin isn't drawn in the view.
