### PR TITLE
Feat/improve vertical spacing

### DIFF
--- a/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/CompareSubgraphs.java
+++ b/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/CompareSubgraphs.java
@@ -125,12 +125,12 @@ public class CompareSubgraphs {
    * contain more genomes, because with more genomes the chance of many mutations is higher.
    *
    * @param nodes       the nodes to calculate the height for.
-   * @param totalHeight the total vertical space to devide between the nodes.
+   * @param totalHeight the total vertical space to divide between the nodes.
    * @return the vertical space to give each node.
    */
   @SuppressWarnings("checkstyle:MethodLength")
   private static int[] calculateNodeHeights(Collection<GraphNode> nodes, int totalHeight) {
-    // devide 25 percent of the space evenly amongst the parts
+    // divide 25 percent of the space evenly amongst the parts
     int[] heights = new int[nodes.size()];
     int evenSpace = totalHeight / 4;
     for (int i = 0; i < nodes.size(); i++) {
@@ -138,13 +138,13 @@ public class CompareSubgraphs {
     }
     heights[0] += evenSpace % nodes.size(); // use the leftover space
 
-    // devide the other 75 percent based on the amount of genomes which goes through each node
+    // divide the other 75 percent based on the amount of genomes which goes through each node
     int totalGenomes = 0;
     for (GraphNode node : nodes) {
       totalGenomes += node.getGenomeSize();
     }
     if (totalGenomes == 0) {
-      devideHeightsEvenly(heights, totalHeight);
+      divideHeightsEvenly(heights, totalHeight);
       return heights;
     }
     int leftoverSpace = totalHeight - evenSpace;
@@ -158,7 +158,7 @@ public class CompareSubgraphs {
     return heights;
   }
 
-  private static void devideHeightsEvenly(int[] heights, int totalHeight) {
+  private static void divideHeightsEvenly(int[] heights, int totalHeight) {
     int heightPerPart = totalHeight / heights.length;
     for (int i = 0; i < heights.length; i++) {
       heights[i] = heightPerPart;

--- a/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SubgraphAlgorithmManager.java
+++ b/PL2/PL2-core/src/main/java/nl/tudelft/pl2016gr2/core/algorithms/subgraph/SubgraphAlgorithmManager.java
@@ -44,6 +44,7 @@ public class SubgraphAlgorithmManager {
    * @return a pair containing as left value the ordered graph of the top subgraph and as right
    *         value the ordered graph of the bottom subgraph.
    */
+  @SuppressWarnings("checkstyle:MethodLength")
   public static Pair<OrderedGraph, OrderedGraph> compareTwoGraphs(Collection<Integer> topGenomes,
       Collection<Integer> bottomGenomes, SequenceGraph mainGraph, GraphOrdererThread mainGraphOrder,
       IPhylogeneticTreeRoot<?> treeRoot) {
@@ -65,6 +66,8 @@ public class SubgraphAlgorithmManager {
     ArrayList<GraphNode> topGraphOrder = topFilter.getOrderedNodes();
     ArrayList<GraphNode> bottomGraphOrder = bottomFilter.getOrderedNodes();
     CompareSubgraphs.compareGraphs(topGraphOrder, bottomGraphOrder);
+    addDummyNodes(topGraphOrder);
+    addDummyNodes(bottomGraphOrder);
 
     OrderedGraph orderedTopGraph = new OrderedGraph(topSubGraphThread.getSubGraph(), topGraphOrder);
     OrderedGraph orderedBottomGraph = new OrderedGraph(bottomSubGraphThread.getSubGraph(),
@@ -91,7 +94,9 @@ public class SubgraphAlgorithmManager {
 
     ArrayList<GraphNode> orderedNodes = subgraph.getOrderedGraph();
     orderedNodes = performBubblingAlgorithms(orderedNodes, genomes, treeRoot);
-
+    
+    CompareSubgraphs.alignVertically(orderedNodes);
+    addDummyNodes(orderedNodes);
     return new OrderedGraph(subgraph, orderedNodes);
   }
 
@@ -115,9 +120,6 @@ public class SubgraphAlgorithmManager {
       GraphBubbleFilter graphFilter = new GraphBubbleFilter(orderedNodes);
       orderedNodes = graphFilter.filter();
     }
-    CompareSubgraphs.alignVertically(orderedNodes);
-
-    addDummyNodes(orderedNodes);
     return orderedNodes;
   }
 
@@ -130,7 +132,6 @@ public class SubgraphAlgorithmManager {
     ArrayList<GraphNode> newNodes = new ArrayList<>();
     for (GraphNode node : orderedNodes) {
       if (node.getInEdges().isEmpty()) {
-
         SequenceNode newerRoot = new SequenceNode(getUniqueDummyNodeId(), new BaseSequence(""));
         node.addInEdge(newerRoot);
         newerRoot.addOutEdge(node);

--- a/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/graph/GraphPaneController.java
+++ b/PL2/PL2-gui/src/main/java/nl/tudelft/pl2016gr2/gui/view/graph/GraphPaneController.java
@@ -1024,11 +1024,13 @@ public class GraphPaneController implements Initializable {
     drawnGraphNodes.forEach((GraphNode node) -> {
       if (!node.isPopped()) {
         for (GraphNode outEdge : node.getOutEdges()) {
-          double edgeWidth = calculateEdgeWidth(genomeCount, node, outEdge);
-          drawEdge(canvas.getGraphicsContext2D(), node, outEdge, edgeWidth, startLevel);
+          if (outEdge.getGuiData().range != null) {
+            double edgeWidth = calculateEdgeWidth(genomeCount, node, outEdge);
+            drawEdge(canvas.getGraphicsContext2D(), node, outEdge, edgeWidth, startLevel);
+          }
         }
         for (GraphNode inEdge : node.getInEdges()) {
-          if (!drawnGraphNodes.contains(inEdge)) {
+          if (inEdge.getGuiData().range != null && !drawnGraphNodes.contains(inEdge)) {
             double edgeWidth = calculateEdgeWidth(genomeCount, inEdge, node);
             drawEdge(canvas.getGraphicsContext2D(), inEdge, node, edgeWidth, startLevel);
           }

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/AbstractGraphBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/AbstractGraphBubble.java
@@ -38,15 +38,6 @@ public abstract class AbstractGraphBubble extends Bubble {
     this.filter = filter;
   }
   
-  @Override
-  public int getGenomeSize() {
-    int count = 0;
-    for (GraphNode inEdge : getInEdges()) {
-      count += inEdge.getGenomeSize();
-    }
-    return count;
-  }
-  
   /**
    * Returns the bubblefilter of this bubble.
    * 

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/Bubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/Bubble.java
@@ -128,14 +128,15 @@ public abstract class Bubble extends AbstractGraphNode implements GraphNode {
 
   @Override
   public List<Integer> getGenomes() {
-    ArrayList<Integer> genomes = new ArrayList<>();
+    HashSet<Integer> genomeSet = new HashSet<>();
     for (GraphNode nestedNode : nestedNodes) {
-      genomes.addAll(nestedNode.getGenomes());
+      genomeSet.addAll(nestedNode.getGenomes());
     }
-    genomes.sort(null);
-    return genomes;
+    ArrayList<Integer> sortedGenomes = new ArrayList<>(genomeSet);
+    sortedGenomes.sort(null);
+    return sortedGenomes;
   }
-  
+
 
   @Override
   public boolean containsGenome(Integer genome) {

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/GraphBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/GraphBubble.java
@@ -10,8 +10,8 @@ public class GraphBubble extends AbstractGraphBubble {
   /**
    * Construct a graph bubble.
    *
-   * @param id       the id of the bubble.
-   * @param filter   the filter object to call when zooming in.
+   * @param id     the id of the bubble.
+   * @param filter the filter object to call when zooming in.
    */
   public GraphBubble(int id, BubbleFilter filter) {
     super(id, filter);
@@ -39,7 +39,7 @@ public class GraphBubble extends AbstractGraphBubble {
    * @param outEdges    the out edges of the bubble.
    * @param nestedNodes the nested nodes of the bubble.
    */
-  public GraphBubble(int id, BubbleFilter filter, Collection<GraphNode> inEdges, 
+  public GraphBubble(int id, BubbleFilter filter, Collection<GraphNode> inEdges,
       Collection<GraphNode> outEdges, HashSet<GraphNode> nestedNodes) {
     super(id, filter, inEdges, outEdges, nestedNodes);
   }
@@ -47,8 +47,8 @@ public class GraphBubble extends AbstractGraphBubble {
   /**
    * Copy a graph bubble.
    *
-   * @param bubble   the super class of the phylo bubble to copy.
-   * @param filter   the filter object to call when zooming in.
+   * @param bubble the super class of the phylo bubble to copy.
+   * @param filter the filter object to call when zooming in.
    */
   private GraphBubble(Bubble bubble, BubbleFilter filter) {
     super(bubble, filter);
@@ -68,11 +68,18 @@ public class GraphBubble extends AbstractGraphBubble {
   public String toString() {
     return String.format("%s: \n%s", "Random Bubble", super.toString());
   }
-  
+
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
   }
+
+  @Override
+  public int getGenomeSize() {
+    int count = 0;
+    for (GraphNode inEdge : getInEdges()) {
+      count += inEdge.getGenomeSize();
+    }
+    return count;
+  }
 }
-
-

--- a/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/PhyloBubble.java
+++ b/PL2/PL2-shared/src/main/java/nl/tudelft/pl2016gr2/model/graph/nodes/PhyloBubble.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 public class PhyloBubble extends AbstractGraphBubble {
 
   private final IPhylogeneticTreeNode treeNode;
+  private int genomeSize = -1;
 
   /**
    * Construct a phylo bubble.
@@ -93,5 +94,13 @@ public class PhyloBubble extends AbstractGraphBubble {
   @Override
   public void accept(NodeVisitor visitor) {
     visitor.visit(this);
+  }
+
+  @Override
+  public int getGenomeSize() {
+    if (genomeSize == -1) {
+      genomeSize = getGenomes().size();
+    }
+    return genomeSize;
   }
 }


### PR DESCRIPTION
The amount of vertical space which each path through the graph gets now depends on the amount of genomes which go through the path.
Each path gets 25% of the space by default and the rest of the vertical space is divided according to the amount of genomes.

Before:
![before changes](https://cloud.githubusercontent.com/assets/9753699/16179430/07326762-3666-11e6-94d9-3082cb42adb6.png)

After:
![after changes](https://cloud.githubusercontent.com/assets/9753699/16179431/10b381e0-3666-11e6-8a0d-cd5ca0030bed.png)

The path are sorted from top to bottom with at the top the path with the least genomes and at the bottom the path with the most genomes. This means the most common path isn't in the center anymore, but this is the easiest way to avoid a lot of edge collisions.
